### PR TITLE
Fixes Windows USB Enumeration & Enhances Host Discovery

### DIFF
--- a/.claude/skills/faultycat-fase-actual/SKILL.md
+++ b/.claude/skills/faultycat-fase-actual/SKILL.md
@@ -17,7 +17,7 @@ description: Contexto activo del rewrite FaultyCat v3 sobre HW v2.x. Consultar a
 | F11-0a EMFI control modal | ✓ smoke verde | `876124f` + `24b38b4` (fix) |
 | F11-0b Crowbar control modal + SharedSerial CDC1 race fix | ✓ smoke verde | `135b32f` |
 | F11-0c Campaign control modal MVP (engine=crowbar) | ✓ code+tests; smoke pendiente | `9640656` |
-| F11-0d Scanner control modal | pending | — |
+| F11-0d Scanner control modal + Windows enum fix | ✓ Windows enum verde (2026-05-25); modal scanner sigue pending | — |
 | F11-0e Target UART panel CDC3 | pending | — |
 | F11-0f Reflash via magic baud 1200 | pending | — |
 | F11-0g Help modal `?` | pending | — |

--- a/FAULTYCAT_REFACTOR_PLAN.md
+++ b/FAULTYCAT_REFACTOR_PLAN.md
@@ -499,7 +499,7 @@ Cada driver expone comando `diag <driver>` por UART serial (temporal, antes de U
 **Stack:**
 - `pyproject.toml` estándar — operator elige su tooling (uv / poetry / hatch / plain pip).
 - Python 3.10+ baseline.
-- USB enum: `pyserial` + `udevadm` helper (Linux primary; Windows/macOS = TODO de F11 polish).
+- USB enum: `pyserial` `list_ports.comports()` cross-platform (Linux, Windows, macOS) — el interface number sale del trailing `.N` del campo `port.location` (Linux `1-3:1.N` / Windows `1-3:x.N`) o del token `MI_XX` en `port.hwid` (Windows). `udevadm` se conserva como fallback Linux. Soporte Windows cerrado durante F11-0d junto con los descriptor fixes (`bcdUSB=0x0210`, attributes bus-powered, init order que sirve `tud_task` durante los driver inits, y cooperative sleep en el main loop que cambió `sleep_ms(20)` por `tud_task` cada 1 ms).
 
 **Criterio:** TUI interactiva cubre 100% del faultycmd viejo + campañas + switch entre EMFI/crowbar/scanner. CLI cubre 100% de los 4 reference Python clients (estos quedan como deprecated reference hasta F11 archive).
 

--- a/FAULTYCAT_REFACTOR_PLAN.md
+++ b/FAULTYCAT_REFACTOR_PLAN.md
@@ -712,7 +712,7 @@ description: Contexto activo del rewrite FaultyCat v3 sobre HW v2.x. Consultar a
 ## En qué estamos
 Descriptor USB composite con 4 CDC + vendor + HID.
 CDC emfi y CDC crowbar pasan echo. CDC scanner y target-uart pendientes.
-Issue abierto: Windows no enumera bien el 4to CDC — investigar IAD order.
+~~Issue abierto: Windows no enumera bien el 4to CDC — investigar IAD order.~~ → Cerrado durante F11-0d (2026-05-25). Causa raíz NO era IAD order: era una combinación de (1) `bcdUSB=0x0201` (revisión USB-IF inexistente — Windows entraba a un parser fallback que no recorría los IADs, así `usbser.sys` nunca se bindaba; corregido a `0x0210`); (2) `SELF_POWERED | REMOTE_WAKEUP` declarados sin implementar (la placa es bus-powered — cambiado a `attributes=0`); (3) `usb_composite_init()` arrancaba TinyUSB pero los 13 driver inits a continuación bloqueaban el main thread antes del primer `tud_task()`, así Windows hacía timeout en el primer GET_DESCRIPTOR (`Code 43` / `DEVICE_DESCRIPTOR_FAILURE`); (4) el `hal_sleep_ms(20)` al final de cada iteración del main loop era `sleep_ms()` busy-wait sin `tud_task()`, otro starvation point. Fixes en `usb/src/usb_descriptors.c` (bcdUSB + attributes) y `apps/faultycat_fw/main.c` (50× `tud_task` con `busy_wait_us(100)` post-`usb_composite_init` + cooperative sleep que llama `tud_task` cada 1 ms en lugar del `sleep_ms` bloqueante). Linux toleraba todo lo anterior por su tolerancia a timeouts/parser quirks.
 
 ## Qué NO tocar
 - services/glitch_engine/ (F4–F5)
@@ -722,7 +722,7 @@ Issue abierto: Windows no enumera bien el 4to CDC — investigar IAD order.
 ## Salida de F3
 [x] lsusb -v muestra 10 interfaces
 [x] ttyACM0..3 aparecen en Linux
-[ ] COM0..3 aparecen en Windows
+[x] COM0..3 aparecen en Windows (cerrado F11-0d 2026-05-25)
 [ ] /dev/cu.usbmodem*×4 en macOS
 [ ] openocd responde a DAP_Info
 [ ] docs/USB_COMPOSITE.md completo

--- a/apps/faultycat_fw/main.c
+++ b/apps/faultycat_fw/main.c
@@ -1253,6 +1253,17 @@ static void pump_crowbar_cdc(void) {
 int main(void) {
     usb_composite_init();
 
+    // Service USB SETUP packets that arrive while the rest of the
+    // drivers come up. Windows hosts can fire GET_DESCRIPTOR within
+    // a few ms of bus reset; if tud_task() doesn't run until after
+    // all 13 driver inits below, those early SETUPs sit unanswered
+    // long enough for Windows to abort enumeration with Code 43
+    // (Linux retries longer and recovers).
+    for (int i = 0; i < 50; i++) {
+        usb_composite_task();
+        hal_busy_wait_us(100);
+    }
+
     ui_leds_init();
     ui_buttons_init();
     target_monitor_init();
@@ -1342,6 +1353,14 @@ int main(void) {
             last_snapshot_ms = now;
         }
 
-        hal_sleep_ms(BUTTON_POLL_PERIOD_MS);
+        // Cooperative sleep: pump usb_composite_task every 1 ms instead
+        // of blocking BUTTON_POLL_PERIOD_MS straight. sleep_ms() in
+        // pico-sdk is a busy-wait that does NOT service tud_task, so
+        // Windows SETUPs arriving during that 20 ms window pile up
+        // and trigger Code 43 / DEVICE_DESCRIPTOR_FAILURE.
+        for (uint32_t i = 0; i < BUTTON_POLL_PERIOD_MS; i++) {
+            usb_composite_task();
+            hal_busy_wait_us(1000);
+        }
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -407,7 +407,15 @@ changed.
 
 ```
 faultycmd.framing               — CRC16-CCITT helper + frame builder
-faultycmd.usb                   — port → CDC mapping (udevadm helper)
+faultycmd.usb                   — port → CDC mapping. Cross-platform
+                                  via pyserial list_ports on Linux,
+                                  Windows, macOS; udevadm kept as a
+                                  Linux fallback. Interface number
+                                  pulled from the trailing ".N" of
+                                  `port.location` (works for both
+                                  Linux "1-3:1.N" and Windows
+                                  "1-3:x.N" pyserial outputs) or
+                                  "MI_XX" in the Windows hwid.
 faultycmd.persistence           — XDG last-config store, one slot per
                                   engine: emfi / crowbar / campaign /
                                   scanner

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,9 +62,12 @@ Current tree health:
 - **9 drivers** implemented (8 active + `voltage_mux` stub) under `drivers/`.
 - **USB composite** up on VID:PID `1209:fa17`. 10 interfaces
   (4×CDC + Vendor + HID). 16/16 endpoints used (hard RP2040 limit).
-  BOS + MS OS 2.0 descriptors for Windows WinUSB auto-bind.
-  Magic baud 1200 on any CDC → `reset_usb_boot()` (remote BOOTSEL).
-  CDC0 now owned by `host_proto/emfi_proto`.
+  `bcdUSB=0x0210` + BOS + MS OS 2.0 descriptors for Windows WinUSB
+  auto-bind on the vendor IF; the 4 CDCs bind to `usbser.sys` (Linux:
+  `cdc_acm`). Config descriptor declares bus-powered with no
+  remote-wakeup (attributes=0). Magic baud 1200 on any CDC →
+  `reset_usb_boot()` (remote BOOTSEL). CDC0 now owned by
+  `host_proto/emfi_proto`.
 - **HAL** headers live: `gpio`, `time` (+busy_wait +irq ctl), `adc`,
   `pwm`, `pio` ✓ F4-1, `dma` ✓ F4-2. `usb` stays `#error` stub
   (won't be lifted — TinyUSB is the abstraction).

--- a/host/faultycmd-py/README.md
+++ b/host/faultycmd-py/README.md
@@ -18,7 +18,9 @@ scripts and the four reference clients under `tools/` with a single
 ```
 faultycmd/
 ├── framing.py              CRC16-CCITT + frame builder/parser
-├── usb.py                  port → CDC mapping helper (udevadm wrapped)
+├── usb.py                  port → CDC mapping helper (cross-platform:
+│                           pyserial list_ports on Linux/Windows/macOS,
+│                           udevadm as Linux fallback)
 ├── persistence.py          XDG last-config store (one slot per engine:
 │                           emfi / crowbar / campaign / scanner)
 ├── protocols/

--- a/host/faultycmd-py/src/faultycmd/usb.py
+++ b/host/faultycmd-py/src/faultycmd/usb.py
@@ -1,12 +1,15 @@
 """Port → CDC interface mapping helper.
 
-Linux primary: walks ``/dev/ttyACM*`` and uses ``udevadm info`` to
-identify which interface number each ACM node maps to within the
-FaultyCat v3 composite device (VID 0x1209 / PID 0xFA17).
+Cross-platform: uses ``pyserial.tools.list_ports`` so the same code
+works on Linux (``/dev/ttyACM*``), Windows (``COM*``), and macOS
+(``/dev/cu.usbmodem*``). Each port carries its VID/PID and either
+a location string (Linux/macOS) or an ``MI_xx`` token in its hwid
+(Windows) from which we recover the interface number inside the
+composite.
 
-Windows / macOS support is a TODO of F11 release polish; the helper
-falls back to a heuristic that scans a list of candidate device
-nodes if udevadm isn't available.
+On Linux ``udevadm`` is kept as a fallback for systems where
+pyserial's location parsing misses the interface number (older
+pyserial, weird kernel).
 
 The composite layout (frozen in F3 — see
 ``docs/ARCHITECTURE.md::USB composite``):
@@ -22,18 +25,20 @@ IF 8                Vendor — CMSIS-DAP v2 (no /dev node)
 IF 9                HID — CMSIS-DAP v1    (no /dev node)
 ==================  ====================  =======================
 
-The trailing /dev/ttyACM<N> numbers are NOT stable across reboots
-or when other USB-CDC devices share the namespace, so this module
-always re-discovers via udevadm.
+OS-stable port names (``/dev/ttyACMx`` numbering, ``COM<n>`` index)
+shuffle across reboots / hot-plugs, so this module always
+re-discovers by VID:PID and interface number rather than caching.
 """
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Literal
+
+from serial.tools import list_ports
 
 log = logging.getLogger(__name__)
 
@@ -56,67 +61,81 @@ class FaultyCatPort:
     """One CDC interface of the FaultyCat composite."""
 
     interface: int
-    device: str   # e.g. "/dev/ttyACM3"
+    device: str   # "/dev/ttyACMx" on Linux, "COMx" on Windows
 
 
 class PortDiscoveryError(LookupError):
     """No FaultyCat CDC matched the requested role."""
 
 
-def _udev_props(device: str) -> dict[str, str]:
-    """Return the relevant udev properties for `device`, or {} on failure."""
-    if not shutil.which("udevadm"):
-        return {}
-    try:
-        out = subprocess.check_output(
-            ["udevadm", "info", "--query=property", device],
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-    except (subprocess.CalledProcessError, OSError):
-        return {}
-    props: dict[str, str] = {}
-    for line in out.splitlines():
-        if "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        props[key.strip()] = value.strip()
-    return props
+# Windows hwid carries the interface number as "MI_XX" (hex).
+_WIN_MI_RE = re.compile(r"MI_([0-9A-Fa-f]{2})")
+
+# pyserial's `location` field carries the interface number as the
+# last ".<n>" segment:
+#   Linux:   "1-3:1.4"   → 4
+#   Windows: "1-3:x.6"   → 6  (yes, literal 'x' — config index is
+#                              unknown on Windows so pyserial fills it
+#                              with that placeholder)
+#   macOS:   "<addr>.<n>" → n
+_LOCATION_IFACE_RE = re.compile(r"\.(\d+)\s*$")
+
+
+def _interface_from_port(port) -> int | None:
+    """Best-effort interface-number extraction from a ListPortInfo.
+
+    Tries (in order):
+      1. ``MI_XX`` in ``hwid`` (Windows convention).
+      2. Trailing ``.<n>`` in ``location`` (Linux/macOS pyserial).
+      3. ``udevadm info`` for ``ID_USB_INTERFACE_NUM`` (Linux fallback).
+    """
+    hwid = port.hwid or ""
+    m = _WIN_MI_RE.search(hwid)
+    if m:
+        return int(m.group(1), 16)
+
+    loc = port.location or ""
+    m = _LOCATION_IFACE_RE.search(loc)
+    if m:
+        return int(m.group(1))
+
+    if shutil.which("udevadm"):
+        try:
+            out = subprocess.check_output(
+                ["udevadm", "info", "--query=property", port.device],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            for line in out.splitlines():
+                if line.startswith("ID_USB_INTERFACE_NUM="):
+                    return int(line.partition("=")[2].strip())
+        except (subprocess.CalledProcessError, OSError):
+            pass
+
+    return None
 
 
 def discover() -> list[FaultyCatPort]:
-    """Walk ``/dev/ttyACM*`` and return ports owned by the FaultyCat
-    composite, sorted by interface number.
-
-    Returns an empty list on platforms without ``/dev/ttyACM*`` or
-    without ``udevadm`` (Windows / macOS — TODO F11).
-    """
+    """Return all FaultyCat composite CDC ports, sorted by interface."""
     found: list[FaultyCatPort] = []
-    for dev_path in sorted(Path("/dev").glob("ttyACM*")):
-        props = _udev_props(str(dev_path))
-        if not props:
+    for port in list_ports.comports():
+        if port.vid != VID_FAULTYCAT or port.pid != PID_FAULTYCAT:
             continue
-        try:
-            vid = int(props.get("ID_VENDOR_ID", "0"), 16)
-            pid = int(props.get("ID_MODEL_ID", "0"), 16)
-            iface_raw = props.get("ID_USB_INTERFACE_NUM")
-        except ValueError:
+        iface = _interface_from_port(port)
+        if iface is None:
+            log.warning(
+                "found FaultyCat CDC at %s but could not determine its "
+                "interface number (hwid=%r, location=%r) — skipping",
+                port.device, port.hwid, port.location,
+            )
             continue
-        if vid != VID_FAULTYCAT or pid != PID_FAULTYCAT:
-            continue
-        if iface_raw is None:
-            continue
-        try:
-            iface = int(iface_raw)
-        except ValueError:
-            continue
-        found.append(FaultyCatPort(interface=iface, device=str(dev_path)))
+        found.append(FaultyCatPort(interface=iface, device=port.device))
     found.sort(key=lambda p: p.interface)
     return found
 
 
 def cdc_for(role: Role) -> str:
-    """Return the ``/dev/ttyACM<N>`` matching the requested CDC role.
+    """Return the device path/name matching the requested CDC role.
 
     Raises:
         ValueError: ``role`` not in INTERFACE_NUMBERS.

--- a/host/faultycmd-py/tests/test_usb.py
+++ b/host/faultycmd-py/tests/test_usb.py
@@ -1,116 +1,156 @@
 """Unit tests for faultycmd.usb — port discovery + role mapping.
 
-Tests mock subprocess + Path.glob so they pass on any platform
-(don't depend on a real udevadm or /dev/ttyACM*).
+Mocks pyserial's list_ports.comports() so tests pass on any
+platform (don't depend on a real /dev/ttyACM* or COMx).
 """
 from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
 
 import pytest
 
 from faultycmd import usb
 
 
-def _udev_text(vid: str, pid: str, iface: str) -> str:
-    return (
-        f"ID_VENDOR_ID={vid}\n"
-        f"ID_MODEL_ID={pid}\n"
-        f"ID_USB_INTERFACE_NUM={iface}\n"
+@dataclass
+class FakePort:
+    """Minimal stand-in for pyserial's ListPortInfo."""
+
+    device: str
+    vid: Optional[int]
+    pid: Optional[int]
+    hwid: str = ""
+    location: Optional[str] = None
+
+
+def _linux_port(dev: str, vid: int, pid: int, iface: int) -> FakePort:
+    return FakePort(
+        device=dev,
+        vid=vid,
+        pid=pid,
+        hwid=f"USB VID:PID={vid:04X}:{pid:04X}",
+        location=f"1-3:1.{iface}",
+    )
+
+
+def _windows_port(dev: str, vid: int, pid: int, iface: int) -> FakePort:
+    # Real Windows pyserial output for usbser.sys-backed composite CDCs
+    # exposes the interface number via the location's trailing ".N".
+    # The hwid string has the same VID:PID=... LOCATION=... shape as
+    # Linux (no MI_XX token), so we rely on location parsing.
+    return FakePort(
+        device=dev,
+        vid=vid,
+        pid=pid,
+        hwid=(
+            f"USB VID:PID={vid:04X}:{pid:04X} SER=FLT3-XXXX "
+            f"LOCATION=1-3:x.{iface}"
+        ),
+        location=f"1-3:x.{iface}",
     )
 
 
 @pytest.fixture
-def fake_environment(monkeypatch):
-    """Pretend /dev/ttyACM0..3 belong to FaultyCat at IF 0/2/4/6, ttyACM4 belongs to a different vendor."""
-    fake_devs = ["ttyACM0", "ttyACM1", "ttyACM2", "ttyACM3", "ttyACM4"]
-    udev_table = {
-        "/dev/ttyACM0": _udev_text("1209", "fa17", "00"),
-        "/dev/ttyACM1": _udev_text("1209", "fa17", "02"),
-        "/dev/ttyACM2": _udev_text("1209", "fa17", "04"),
-        "/dev/ttyACM3": _udev_text("1209", "fa17", "06"),
-        "/dev/ttyACM4": _udev_text("0403", "6001", "00"),  # FTDI cable
-    }
-
-    class FakePath:
-        def __init__(self, p: str):
-            self.p = p
-
-        def __str__(self) -> str:
-            return self.p
-
-        def __lt__(self, other) -> bool:
-            return self.p < other.p
-
-    def fake_glob(self, pattern):
-        if pattern == "ttyACM*":
-            return [FakePath(f"/dev/{d}") for d in fake_devs]
-        return []
-
-    def fake_check_output(cmd, **kwargs):
-        if not (isinstance(cmd, list) and "udevadm" in cmd[0]):
-            raise FileNotFoundError
-        device = cmd[-1]
-        text = udev_table.get(device)
-        if text is None:
-            raise __import__("subprocess").CalledProcessError(1, cmd)
-        return text
-
-    monkeypatch.setattr("pathlib.Path.glob", fake_glob)
-    monkeypatch.setattr("subprocess.check_output", fake_check_output)
-    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/udevadm" if name == "udevadm" else None)
-    return udev_table
+def linux_environment(monkeypatch):
+    """ttyACM0..3 belong to FaultyCat at IF 0/2/4/6, ttyACM4 is FTDI."""
+    ports = [
+        _linux_port("/dev/ttyACM0", 0x1209, 0xFA17, 0x00),
+        _linux_port("/dev/ttyACM1", 0x1209, 0xFA17, 0x02),
+        _linux_port("/dev/ttyACM2", 0x1209, 0xFA17, 0x04),
+        _linux_port("/dev/ttyACM3", 0x1209, 0xFA17, 0x06),
+        _linux_port("/dev/ttyACM4", 0x0403, 0x6001, 0x00),
+    ]
+    monkeypatch.setattr("faultycmd.usb.list_ports.comports", lambda: ports)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    return ports
 
 
-def test_discover_finds_only_faultycat(fake_environment):
+@pytest.fixture
+def windows_environment(monkeypatch):
+    """COM3..6 belong to FaultyCat at IF 0/2/4/6, COM7 is a USB-UART."""
+    ports = [
+        _windows_port("COM3", 0x1209, 0xFA17, 0x00),
+        _windows_port("COM4", 0x1209, 0xFA17, 0x02),
+        _windows_port("COM5", 0x1209, 0xFA17, 0x04),
+        _windows_port("COM6", 0x1209, 0xFA17, 0x06),
+        _windows_port("COM7", 0x10C4, 0xEA60, 0x00),  # CP2102
+    ]
+    monkeypatch.setattr("faultycmd.usb.list_ports.comports", lambda: ports)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    return ports
+
+
+def test_discover_linux_finds_only_faultycat(linux_environment):
     ports = usb.discover()
     assert len(ports) == 4
     assert {p.interface for p in ports} == {0, 2, 4, 6}
-    # FTDI device on ACM4 must NOT appear.
     assert all("ttyACM4" not in p.device for p in ports)
 
 
-def test_discover_sorted_by_interface(fake_environment):
+def test_discover_windows_finds_only_faultycat(windows_environment):
     ports = usb.discover()
-    interfaces = [p.interface for p in ports]
-    assert interfaces == sorted(interfaces)
+    assert len(ports) == 4
+    assert {p.interface for p in ports} == {0, 2, 4, 6}
+    assert all(p.device != "COM7" for p in ports)
 
 
-def test_cdc_for_emfi(fake_environment):
+def test_discover_sorted_by_interface(linux_environment):
+    ports = usb.discover()
+    assert [p.interface for p in ports] == [0, 2, 4, 6]
+
+
+def test_cdc_for_emfi_linux(linux_environment):
     assert usb.cdc_for("emfi") == "/dev/ttyACM0"
 
 
-def test_cdc_for_crowbar(fake_environment):
+def test_cdc_for_crowbar_linux(linux_environment):
     assert usb.cdc_for("crowbar") == "/dev/ttyACM1"
 
 
-def test_cdc_for_scanner(fake_environment):
+def test_cdc_for_scanner_linux(linux_environment):
     assert usb.cdc_for("scanner") == "/dev/ttyACM2"
 
 
-def test_cdc_for_target(fake_environment):
+def test_cdc_for_target_linux(linux_environment):
     assert usb.cdc_for("target") == "/dev/ttyACM3"
 
 
-def test_cdc_for_unknown_role_raises(fake_environment):
+def test_cdc_for_emfi_windows(windows_environment):
+    assert usb.cdc_for("emfi") == "COM3"
+
+
+def test_cdc_for_crowbar_windows(windows_environment):
+    assert usb.cdc_for("crowbar") == "COM4"
+
+
+def test_cdc_for_scanner_windows(windows_environment):
+    assert usb.cdc_for("scanner") == "COM5"
+
+
+def test_cdc_for_target_windows(windows_environment):
+    assert usb.cdc_for("target") == "COM6"
+
+
+def test_cdc_for_unknown_role_raises(linux_environment):
     with pytest.raises(ValueError):
         usb.cdc_for("dap")  # type: ignore[arg-type]
 
 
 def test_cdc_for_no_match_raises(monkeypatch):
-    # Empty environment — discover() returns nothing.
-    monkeypatch.setattr("pathlib.Path.glob", lambda self, pat: [])
-    monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.setattr("faultycmd.usb.list_ports.comports", lambda: [])
+    monkeypatch.setattr("shutil.which", lambda _name: None)
     with pytest.raises(usb.PortDiscoveryError):
         usb.cdc_for("emfi")
 
 
-def test_no_udevadm_returns_empty(monkeypatch):
-    monkeypatch.setattr("shutil.which", lambda name: None)
+def test_no_devices_returns_empty(monkeypatch):
+    monkeypatch.setattr("faultycmd.usb.list_ports.comports", lambda: [])
+    monkeypatch.setattr("shutil.which", lambda _name: None)
     assert usb.discover() == []
 
 
 def test_interface_numbers_match_firmware_spec():
-    # Sanity check — the IF 0/2/4/6 layout was frozen at F3 (USB
-    # composite). Drift would mis-map every CDC.
     assert usb.INTERFACE_NUMBERS == {
         "emfi": 0x00,
         "crowbar": 0x02,

--- a/usb/src/usb_descriptors.c
+++ b/usb/src/usb_descriptors.c
@@ -33,9 +33,13 @@
 static const tusb_desc_device_t s_device_desc = {
     .bLength            = sizeof(tusb_desc_device_t),
     .bDescriptorType    = TUSB_DESC_DEVICE,
-    // bcdUSB 2.01 advertises BOS descriptor support so Windows
-    // queries the MS OS 2.0 descriptor set we provide.
-    .bcdUSB             = 0x0201,
+    // bcdUSB 2.1.0 — correct BCD for USB 2.1 (BOS support).
+    // 0x0201 was a typo (USB-IF has no "USB 2.0.1" revision); Windows
+    // accepted it but used a fallback parser that didn't recurse into
+    // the CDC interfaces, so usbser.sys never bound and the 4 COM
+    // ports were invisible (only WinUSB bound to the vendor IF).
+    // Same value debugprobe uses.
+    .bcdUSB             = 0x0210,
     .bDeviceClass       = TUSB_CLASS_MISC,
     .bDeviceSubClass    = MISC_SUBCLASS_COMMON,
     .bDeviceProtocol    = MISC_PROTOCOL_IAD,
@@ -145,7 +149,10 @@ static const uint8_t s_config_desc[] = {
         /* interface count */ ITF_TOTAL,
         /* string index */ 0,
         /* total length */ CONFIG_TOTAL_LEN,
-        /* attributes */ TUSB_DESC_CONFIG_ATT_SELF_POWERED | TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP,
+        // Bus-powered (RP2040 + HV boost both run from VBUS). No
+        // remote-wakeup implementation. Misdeclaring SELF_POWERED
+        // can make Windows reject the device on enumeration.
+        /* attributes */ 0,
         /* power (mA) */ 100
     ),
 


### PR DESCRIPTION
### Summary

Fixes critical Windows USB enumeration issues (Code 43) on the firmware. Enables cross-platform USB CDC serial port discovery in the host tool.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

### Detailed changes

*   **Firmware:**
    *   Initializes USB service early in `main.c` to proactively handle Windows' rapid SETUP requests, preventing enumeration failures.
    *   Modifies the main loop to cooperatively service the USB composite task during sleep periods, ensuring USB packets are processed promptly and avoiding timeouts that lead to Code 43.
    *   Corrects the `bcdUSB` value from `0x0201` to `0x0210` in the device descriptor and removes `SELF_POWERED` attribute, resolving issues with Windows failing to bind CDC interfaces.
*   **Host (`faultycmd-py`):**
    *   Switches USB port discovery from a Linux-specific `udevadm` approach to a cross-platform method leveraging `pyserial.tools.list_ports`.
    *   Adds robust logic to accurately determine CDC interface numbers from port `hwid` and `location` strings on Linux, Windows, and macOS, while retaining `udevadm` as a Linux fallback.
    *   Updates the `SKILL.md` and `README.md` documentation, along with unit tests, to reflect the new cross-platform discovery capabilities.

### Checklist

- [x] Code is self-documented
- [x] Unit tests pass locally
- [x] New/existing tests cover changes
- [x] `releaseNotes.md` updated