### PR TITLE
fix(host): resolve Windows interface detection failure on the first CDC port (COM24 / MI_00)

### DIFF
--- a/host/faultycmd-py/src/faultycmd/usb.py
+++ b/host/faultycmd-py/src/faultycmd/usb.py
@@ -122,6 +122,7 @@ _MACOS_USBMODEM_RE = re.compile(r"\.usbmodem\d+?(\d)$")
 def _get_win_pnp_id(port_name: str) -> str | None:
     try:
         import winreg
+        
         usb_path = r"SYSTEM\CurrentControlSet\Enum\USB"
         with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, usb_path) as usb_key:
             num_devices = winreg.QueryInfoKey(usb_key)[0]
@@ -135,7 +136,9 @@ def _get_win_pnp_id(port_name: str) -> str | None:
                             try:
                                 with winreg.OpenKey(dev_key, inst_name) as inst_key:
                                     try:
-                                        with winreg.OpenKey(inst_key, "Device Parameters") as params_key:
+                                        with winreg.OpenKey(
+                                            inst_key, "Device Parameters"
+                                        ) as params_key:
                                             port, _ = winreg.QueryValueEx(params_key, "PortName")
                                             if port == port_name:
                                                 return f"USB\\{dev_name}\\{inst_name}"
@@ -176,13 +179,13 @@ def _interface_from_port(port) -> int | None:
 
     # Windows fallback: query PNP Device ID via registry to find MI_XX
     import sys
+
     if sys.platform == "win32" and port.device:
         pnp_id = _get_win_pnp_id(port.device)
         if pnp_id:
             m = _WIN_MI_RE.search(pnp_id)
             if m:
                 return int(m.group(1), 16)
-
 
     if shutil.which("udevadm"):
         try:

--- a/host/faultycmd-py/src/faultycmd/usb.py
+++ b/host/faultycmd-py/src/faultycmd/usb.py
@@ -119,6 +119,37 @@ _INTERFACE_BY_STRING: dict[str, int] = {
 _MACOS_USBMODEM_RE = re.compile(r"\.usbmodem\d+?(\d)$")
 
 
+def _get_win_pnp_id(port_name: str) -> str | None:
+    try:
+        import winreg
+        usb_path = r"SYSTEM\CurrentControlSet\Enum\USB"
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, usb_path) as usb_key:
+            num_devices = winreg.QueryInfoKey(usb_key)[0]
+            for i in range(num_devices):
+                dev_name = winreg.EnumKey(usb_key, i)
+                try:
+                    with winreg.OpenKey(usb_key, dev_name) as dev_key:
+                        num_instances = winreg.QueryInfoKey(dev_key)[0]
+                        for j in range(num_instances):
+                            inst_name = winreg.EnumKey(dev_key, j)
+                            try:
+                                with winreg.OpenKey(dev_key, inst_name) as inst_key:
+                                    try:
+                                        with winreg.OpenKey(inst_key, "Device Parameters") as params_key:
+                                            port, _ = winreg.QueryValueEx(params_key, "PortName")
+                                            if port == port_name:
+                                                return f"USB\\{dev_name}\\{inst_name}"
+                                    except OSError:
+                                        pass
+                            except OSError:
+                                pass
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return None
+
+
 def _interface_from_port(port) -> int | None:
     """Best-effort interface-number extraction from a ListPortInfo.
 
@@ -142,6 +173,16 @@ def _interface_from_port(port) -> int | None:
     m = _LOCATION_IFACE_RE.search(loc)
     if m:
         return int(m.group(1))
+
+    # Windows fallback: query PNP Device ID via registry to find MI_XX
+    import sys
+    if sys.platform == "win32" and port.device:
+        pnp_id = _get_win_pnp_id(port.device)
+        if pnp_id:
+            m = _WIN_MI_RE.search(pnp_id)
+            if m:
+                return int(m.group(1), 16)
+
 
     if shutil.which("udevadm"):
         try:

--- a/host/faultycmd-py/src/faultycmd/usb.py
+++ b/host/faultycmd-py/src/faultycmd/usb.py
@@ -122,7 +122,7 @@ _MACOS_USBMODEM_RE = re.compile(r"\.usbmodem\d+?(\d)$")
 def _get_win_pnp_id(port_name: str) -> str | None:
     try:
         import winreg
-        
+
         usb_path = r"SYSTEM\CurrentControlSet\Enum\USB"
         with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, usb_path) as usb_key:
             num_devices = winreg.QueryInfoKey(usb_key)[0]


### PR DESCRIPTION
#### **Problem**
On Windows hosts, the CLI helper module (`faultycmd.usb`) was failing to resolve the USB interface number for the first CDC port (Interface `0x00`, usually assigned to `emfi` / `COM24`). Because of this, it was skipped during discovery with the following warning:

found FaultyCat CDC at COM24 but could not determine its interface number (hwid='USB VID:PID=1209:FA17 SER=FLT3-...', location=None) — skipping
This occurred due to a combination of two behaviors on Windows:

- **pyserial** strips `MI_XX  from `hwid`: When `pyserial` successfully extracts the USB serial number, product ID, and vendor ID, it overrides the `port.hwid` string with a formatted identifier (e.g., `USB VID:PID=1209:FA17 SER=...`), removing the raw Device Instance ID which contains the `MI_XX` interface marker.
- `location is None for Interface 0`: Windows' SetupAPI / Registry does not populate a location path string (e.g. 1-2:x.2) for Interface `0x00`. However, it does populate it for child interfaces `0x02`, `0x04`, and `0x06`.
Because `COM24` had no `MI_XX` in `hwid` and `location` was `None`, the host tool was completely blind to its interface number.


#### **Solution**
Added a Windows-specific fallback (`_get_win_pnp_id`) inside `_interface_from_port`.
When standard properties fail to yield an interface number on Windows, it queries the registry (`SYSTEM\CurrentControlSet\Enum\USB`) using the port name (e.g. `COM24`) to recover the raw **Device Instance ID** (e.g. `USB\VID_1209&PID_FA17&MI_00\7&1A7A0BCD&0&0000`).
Re-applies the `_WIN_MI_RE` regex matcher to the retrieved PNP Device ID to extract `MI_00` and determine the interface number (`0`).
Placed the registry check at the end of the fallback pipeline in `_interface_from_port` (after the `location` check). This ensures that mock environments in unit tests (`pytest`) that rely on mocked `location` strings do not trigger query calls to the host's actual registry, keeping tests isolated.